### PR TITLE
use portfolio id for component key to fix error

### DIFF
--- a/client/src/components/Callback.jsx
+++ b/client/src/components/Callback.jsx
@@ -77,7 +77,6 @@ class Main extends Component {
             )
         } else {
             const portfolios = data.response.investmentData.portfolios.map(portfolio => {
-                let i = 0;
                 const instruments = portfolio.instruments.map(instrument => {
                     return (
                         <p key={instrument.id}><b>{instrument.name}</b><br/>
@@ -89,7 +88,7 @@ class Main extends Component {
                 });
 
                 return (
-                    <div key={++i}>
+                    <div key={portfolio.id}>
                         <h5>Portfolio ({portfolio.type})</h5>
                         {instruments}
                     </div>


### PR DESCRIPTION
I noticed that an error/warning were thrown when showing multiple portfolios due to same key being used multiple times. I think the counter variable is supposed to be initiated before the `.map()` but using the portfolio ids is a lot better than a counter for a React key.