### PR TITLE
chore(gae): configure auto scaling

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,2 +1,4 @@
 env: flex
 runtime: nodejs
+automatic_scaling:
+  min_num_instances: 1


### PR DESCRIPTION
It's better to explicitly state what auto scaling settings we want instead of relying on GAE defaults.