### PR TITLE
chore(env): hide secret for client

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ npm install
 
 ```
 $ export REACT_APP_CLIENT_ID="<YOUR_CLIENT_ID>"
-$ export REACT_APP_CLIENT_SECRET="<YOUR_CLIENT_SECRET>"
+$ export TINK_CLIENT_SECRET="<YOUR_CLIENT_SECRET>"
 ```
 
 3. Run both the backend (`server.js`) and the frontend (`client` folder) concurrently:

--- a/server.js
+++ b/server.js
@@ -5,7 +5,7 @@ const path = require("path");
 const fetch = require("node-fetch");
 
 const CLIENT_ID = process.env.REACT_APP_CLIENT_ID;
-const CLIENT_SECRET = process.env.REACT_APP_CLIENT_SECRET;
+const CLIENT_SECRET = process.env.TINK_CLIENT_SECRET;
 
 app.use(express.static(path.join(__dirname, "client/build")));
 app.use(bodyParser.json());
@@ -150,7 +150,7 @@ if (!CLIENT_ID) {
 if (!CLIENT_SECRET) {
   console.log(
     "\x1b[33m%s\x1b[0m",
-    "Warning: REACT_APP_CLIENT_SECRET environment variable not set"
+    "Warning: TINK_CLIENT_SECRET environment variable not set"
   );
 }
 


### PR DESCRIPTION
Issue reported here: https://github.com/tink-ab/tink-connect-example/issues/69. We do not want to allow the client to reach the secret; quoting https://create-react-app.dev/docs/adding-custom-environment-variables/:

>These environment variables will be defined for you on process.env. For example, having an environment variable named REACT_APP_NOT_SECRET_CODE will be exposed in your JS as process.env.REACT_APP_NOT_SECRET_CODE.